### PR TITLE
Google analytics added

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -10,7 +10,7 @@ paginate  = 10
 rssLimit  = 10  # Maximum number of items in the RSS feed.
 copyright = "This work is licensed under a Creative Commons Attribution-NonCommercial 4.0 International License." # This message is only used by the RSS template.
 
-# googleAnalytics = ""
+googleAnalytics = "G-GZLHVFY8EK"
 # disqusShortname = ""
 
 archetypeDir = "archetypes"


### PR DESCRIPTION
On HUGO sites, google analytics comes by default, it only needs the googleAnalytics code to be added on the config.toml in order to be activated